### PR TITLE
Add __all__ in `selectors.py`

### DIFF
--- a/DiverseSelector/selectors.py
+++ b/DiverseSelector/selectors.py
@@ -33,6 +33,16 @@ from sklearn.decomposition import PCA
 from sklearn.preprocessing import StandardScaler
 
 
+__all__ = [
+    "MaxMin",
+    "MaxSum",
+    "OptiSim",
+    "DirectedSphereExclusion",
+    "GridPartitioning",
+    "KDTree",
+]
+
+
 class MaxMin(SelectionBase):
     """Selecting compounds using MinMax algorithm.
 


### PR DESCRIPTION
This fixes the problem of importing,

```python
from DiverseSelector.selectors import MaxMin, MaxSum, OptiSim, DirectedSphereExclusion, GridPartitioning, KDTree
```