### PR TITLE
Replace white spaces with underscore for diversity measurement methods

### DIFF
--- a/.github/workflows/ci_codecov.yml
+++ b/.github/workflows/ci_codecov.yml
@@ -30,7 +30,7 @@ jobs:
         python-version: [3.7]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Additional info about the build
       shell: bash
       run: |
@@ -39,7 +39,7 @@ jobs:
         ulimit -a
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
         architecture: x64
@@ -63,7 +63,7 @@ jobs:
         pytest --cov-config=.coveragerc --cov-report=xml --color=yes DiverseSelector/test/
 
     - name: CodeCov
-      uses: codecov/codecov-action@v3.0.0
+      uses: codecov/codecov-action@v3
       with:
         fail_ci_if_error: true
         file: ./coverage.xml

--- a/.github/workflows/ci_tox.yml
+++ b/.github/workflows/ci_tox.yml
@@ -29,7 +29,7 @@ jobs:
         # python-version: [3.7, 3.8, 3.9]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Additional info about the build
       shell: bash
       run: |

--- a/.github/workflows/website_auto.yml
+++ b/.github/workflows/website_auto.yml
@@ -20,7 +20,7 @@ jobs:
   deploy-book:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     # Install dependencies
     - name: Set up Python 3.9
@@ -44,7 +44,7 @@ jobs:
         
     # Push the book's HTML to github-pages
     - name: GitHub Pages action
-      uses: peaceiris/actions-gh-pages@v3.6.1
+      uses: peaceiris/actions-gh-pages@v3
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./book/content/_build/html

--- a/DiverseSelector/diversity.py
+++ b/DiverseSelector/diversity.py
@@ -79,9 +79,9 @@ def compute_diversity(
     func_dict = {
         "entropy": entropy,
         "logdet": logdet,
-        "shannon entropy": shannon_entropy,
+        "shannon_entropy": shannon_entropy,
         "wdud": wdud,
-        "gini coefficient": gini_coefficient,
+        "gini_coefficient": gini_coefficient,
     }
 
     if div_type in func_dict:
@@ -93,7 +93,7 @@ def compute_diversity(
                 "dataset when calculating hypersphere overlap."
             )
         return hypersphere_overlap_of_subset(features, feature_subset)
-    elif div_type == "explicit diversity index":
+    elif div_type == "explicit_diversity_index":
         if cs is None:
             raise ValueError("Attribute `cs` is missing. "
                              "Please input `cs` value to use explicit_diversity_index." )
@@ -197,8 +197,8 @@ def shannon_entropy(x: np.ndarray) -> float:
     .. math::
         H(X) = \sum_{i=1}^{n}-P_i(X)\log{P_i(X)}
 
-    where :math:`X` is the feature matrix, :math:`n` is the number of features, and :math:`P_i(X)` is the
-    proportion of molecules that have feature :math:`i` in :math:`X`.
+    where :math:`X` is the feature matrix, :math:`n` is the number of features, and :math:`P_i(X)`
+    is the proportion of molecules that have feature :math:`i` in :math:`X`.
 
     Higher values mean more diversity.
 
@@ -233,7 +233,8 @@ def shannon_entropy(x: np.ndarray) -> float:
         # sum all non-zero terms
         if p_i == 0:
             raise ValueError(
-                f"Feature {i} has value 0 for all molecules. Remove extraneous feature from data set."
+                f"Feature {i} has value 0 for all molecules. "
+                f"Remove extraneous feature from data set."
             )
         h_x += (-1 * p_i) * np.log10(p_i)
     return h_x

--- a/DiverseSelector/test/test_diversity.py
+++ b/DiverseSelector/test/test_diversity.py
@@ -60,7 +60,7 @@ def test_compute_diversity_default():
 
 def test_compute_diversity_specified():
     """Test compute diversity with a specified div_type."""
-    comp_div = compute_diversity(sample4, "shannon entropy")
+    comp_div = compute_diversity(sample4, "shannon_entropy")
     expected = 0.301029995
     assert_almost_equal(comp_div, expected)
 
@@ -89,13 +89,13 @@ def test_compute_diversity_edi():
     z = np.array([[0, 1, 2], [1, 2, 0], [2, 0, 1]])
     cs = 1
     expected = 56.39551204
-    actual = compute_diversity(z, "explicit diversity index", cs=cs)
+    actual = compute_diversity(z, "explicit_diversity_index", cs=cs)
     assert_almost_equal(expected, actual)
 
 
 def test_compute_diversity_edi_no_cs_error():
     """Test compute diversity with explicit diversity index and no `cs` value given."""
-    assert_raises(ValueError, compute_diversity, sample5, "explicit diversity index")
+    assert_raises(ValueError, compute_diversity, sample5, "explicit_diversity_index")
 
 
 def test_compute_diversity_edi_zero_error():


### PR DESCRIPTION
The original white spaces can be confusing for users.