### PR TITLE
Add 2D symmetric array checking for `converter` module

### DIFF
--- a/DiverseSelector/converter.py
+++ b/DiverseSelector/converter.py
@@ -97,6 +97,9 @@ def sim_to_dist(
         raise ValueError(f"Argument x should either have 1 or 2 dimensions, got {x.ndim}.")
     if x.ndim == 1 and metric in ["co-occurrence", "gravity"]:
         raise ValueError(f"Argument x should be a 2D array when using the {metric} metric.")
+    # check if x is symmetric
+    if x.ndim == 2 and not np.allclose(x, x.T):
+        raise ValueError("Argument x should be a symmetric array.")
 
     # call correct metric function
     if metric in frequency:

--- a/DiverseSelector/converter.py
+++ b/DiverseSelector/converter.py
@@ -43,7 +43,7 @@ __all__ = [
 
 
 def sim_to_dist(
-    x: Union[int, float, np.ndarray], metric: str, scale: float = 1.0
+    x: Union[int, float, np.ndarray], metric: str, scaling_factor: float = 1.0
 ) -> Union[float, np.ndarray]:
     """Convert similarity coefficients to distance array.
 
@@ -57,7 +57,7 @@ def sim_to_dist(
         Supported metrics are "reverse", "reciprocal", "exponential",
         "gaussian", "membership", "correlation", "transition", "co-occurrence",
         "gravity", "confusion", "probability", and "covariance".
-    scaler : float, optional
+    scaling_factor : float, optional
         Scaling factor for the distance array. Default is 1.0.
 
     Returns
@@ -66,7 +66,7 @@ def sim_to_dist(
          Distance value or array.
     """
     # scale the distance matrix
-    x = x * scale
+    x = x * scaling_factor
 
     frequency = {
         "transition": transition,

--- a/DiverseSelector/converter.py
+++ b/DiverseSelector/converter.py
@@ -42,7 +42,9 @@ __all__ = [
 ]
 
 
-def sim_to_dist(x: Union[int, float, np.ndarray], metric: str) -> Union[float, np.ndarray]:
+def sim_to_dist(
+    x: Union[int, float, np.ndarray], metric: str, scale: float = 1.0
+) -> Union[float, np.ndarray]:
     """Convert similarity coefficients to distance array.
 
     Parameters
@@ -55,12 +57,17 @@ def sim_to_dist(x: Union[int, float, np.ndarray], metric: str) -> Union[float, n
         Supported metrics are "reverse", "reciprocal", "exponential",
         "gaussian", "membership", "correlation", "transition", "co-occurrence",
         "gravity", "confusion", "probability", and "covariance".
+    scaler : float, optional
+        Scaling factor for the distance array. Default is 1.0.
 
     Returns
     -------
     dist : float or ndarray
          Distance value or array.
     """
+    # scale the distance matrix
+    x = x * scale
+
     frequency = {
         "transition": transition,
         "co-occurrence": co_occurrence,

--- a/DiverseSelector/tests/test_converter.py
+++ b/DiverseSelector/tests/test_converter.py
@@ -66,9 +66,7 @@ def test_sim_2_dist():
 def test_sim_2_dist_frequency():
     """Test similarity to distance method with a frequency metric."""
     x = np.array([[4, 9, 1], [9, 1, 25], [1, 25, 16]])
-    expected = np.array(
-        [[(1 / 2), (1 / 3), 1], [(1 / 3), 1, (1 / 5)], [1, (1 / 5), (1 / 4)]]
-    )
+    expected = np.array([[(1 / 2), (1 / 3), 1], [(1 / 3), 1, (1 / 5)], [1, (1 / 5), (1 / 4)]])
     actual = cv.sim_to_dist(x, "transition")
     assert_almost_equal(actual, expected, decimal=10)
 
@@ -85,8 +83,9 @@ def test_sim_2_dist_frequency_error():
 
 def test_sim_2_dist_membership():
     """Test similarity to distance method with the membership metric."""
-    x = np.array([[(1 / 2), (1 / 5)], [(1 / 4), (1 / 3)]])
-    expected = np.array([[(1 / 2), (4 / 5)], [(3 / 4), (2 / 3)]])
+    # x = np.array([[(1 / 2), (1 / 5)], [(1 / 4), (1 / 3)]])
+    x = np.array([[1, 1 / 5, 1 / 3], [1 / 5, 1, 4 / 5], [1 / 3, 4 / 5, 1]])
+    expected = np.array([[0, 4 / 5, 2 / 3], [4 / 5, 0, 1 / 5], [2 / 3, 1 / 5, 0]])
     actual = cv.sim_to_dist(x, "membership")
     assert_almost_equal(actual, expected, decimal=10)
 
@@ -100,6 +99,12 @@ def test_sim_2_dist_membership_error():
 def test_sim_2_dist_invalid_metric():
     """Test similarity to distance method with an unsupported metric."""
     assert_raises(ValueError, cv.sim_to_dist, np.ones(5), "testing")
+
+
+def test_sim_2_dist_non_symmetric():
+    """Test the invalid 2D symmetric matrix error."""
+    x = np.array([[1, 2], [4, 5]])
+    assert_raises(ValueError, cv.sim_to_dist, x, "reverse")
 
 
 # Tests for individual metrics
@@ -195,9 +200,7 @@ def test_correlation_error():
 def test_transition():
     """Test the transition function for frequency to distance conversion."""
     x = np.array([[4, 9, 1], [9, 1, 25], [1, 25, 16]])
-    expected = np.array(
-        [[(1 / 2), (1 / 3), 1], [(1 / 3), 1, (1 / 5)], [1, (1 / 5), (1 / 4)]]
-    )
+    expected = np.array([[(1 / 2), (1 / 3), 1], [(1 / 3), 1, (1 / 5)], [1, (1 / 5), (1 / 4)]])
 
     actual = cv.transition(x)
     assert_almost_equal(actual, expected, decimal=10)


### PR DESCRIPTION
Also fixed the failing tests because of non-symmetric matrix used. This PR is the final attempt to address #123.